### PR TITLE
Refactor input and unit constructors

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,9 @@
-all :
+all:
 	make project
 	rm *.o 2>/dev/null || echo "rien a clean"
+
+clean:
+	rm -f project *.o
 
 project : main.cpp class_vessel.o class_vessel_ressource.o class_vessel_unite.o class_vessel_tower.o class_unite.o class_input.o player.o load_textures.o
 	g++ main.cpp class_vessel.o class_vessel_ressource.o class_vessel_unite.o class_vessel_tower.o class_unite.o class_input.o player.o load_textures.o -I"include" -o project -Wfatal-errors -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio -lpthread

--- a/source/class_input.cpp
+++ b/source/class_input.cpp
@@ -5,10 +5,8 @@
 using namespace sf;
 using namespace std;
 
-Input::Input()
+Input::Input() : button{false, false, false, false, false}
 {
-     button.left=button.right=button.echap=false;
-     button.down=button.up=false;
 }
 
 Input::Button Input::GetButton(void) const // return private

--- a/source/class_unite.cpp
+++ b/source/class_unite.cpp
@@ -24,16 +24,17 @@ Unites::Unites(sf::Vector2f newposition, sf::Color color, int player, int lvl)
 
     switch (lvl)
     {
-
-        case 1:
-            attaque=50;
-            PV=200;
-            vitesse = 10.f * num_player;
-
         case 2:
-            attaque=50 * lvl;
-            PV=200 * lvl ;
+            attaque = 50 * lvl;
+            PV = 200 * lvl;
             vitesse = 10.f * lvl * num_player;
+            break;
+        case 1:
+        default:
+            attaque = 50;
+            PV = 200;
+            vitesse = 10.f * num_player;
+            break;
     }
 
 }


### PR DESCRIPTION
## Summary
- modernize Input initialization
- fix `Unites` constructor logic
- add `clean` target to makefile for easier builds

## Testing
- `make clean`
- `make`
- `./project` *(fails: Failed to open X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_6887f45853188321aed1315a52c4038a